### PR TITLE
Update site after gig cancellation

### DIFF
--- a/19jun-cotm-poster.jpg
+++ b/19jun-cotm-poster.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:856729ff3b286962064cfe60eb70ef6ceca4ae1fd4d9fb997f43fa4b0c00c3e2
-size 228776

--- a/index.htm
+++ b/index.htm
@@ -9,9 +9,9 @@
     <meta name="author" content="Andrew Wray">
     <link rel="canonical" href="https://bristolemo.com/">
     <link rel="stylesheet" href="main.css">
-    <meta property="og:title" content="Cats on the Moon + Corporate Retreat at The Thunderbolt | Bristol Emo">
-    <meta property="og:description" content="Join Cats on the Moon, Corporate Retreat and Morales at The Thunderbolt on 19 June 2025.">
-    <meta property="og:image" content="https://bristolemo.com/19jun-cotm-poster.jpg">
+    <meta property="og:title" content="Corporate Retreat on hiatus | Bristol Emo">
+    <meta property="og:description" content="Corporate Retreat is going on hiatus, but new music is on the way.">
+    <meta property="og:image" content="https://bristolemo.com/death-and-taxes-small.jpg">
     <meta property="og:url" content="https://bristolemo.com/">
     <meta property="og:type" content="website">
   </head>
@@ -22,25 +22,13 @@
     </header>
     <main>
       <article>
-        <h2>Cats on the Moon + Corporate Retreat + Morales @ The Thunderbolt</h2>
+        <h2>Corporate Retreat on hiatus</h2>
 
-        <p class="m-bottom"><em>Corporate Retreat joins Cats on the Moon and Morales for a shoegaze-infused night.</em></p>
+        <p>After a whirlwind 18 months of live shows, Corporate Retreat is going on permanent hiatus. Andrew is stepping away from public performances to focus on family, his job and his charity work.</p>
 
-        <a href="https://www.thethunderbolt.net/hidden-events-source/2025/6/19/cats-on-the-moon-corperate-retreat">
-          <img alt="Poster for Cats on the Moon, Corporate Retreat and Morales at the Thunderbolt on 19 June 2025." src="19jun-cotm-poster.jpg" height="300" width="212">
-        </a>
+        <p>The music isn't over yet. Andrew will be recording a 15 track studio album for Leonardo Lemuel, the Dune-ical will be played live in August, and Gunkus will be playing more shows this year.</p>
 
-        <p>
-          <strong>Date:</strong> <time datetime="2025-06-19">Thursday 19th June 2025</time>
-        </p>
-
-        <p>
-          <a href="https://www.songkick.com/artists/10321938-cats-on-the-moon">Track them on Songkick!</a>
-        </p>
-
-        <p>
-          <a href="https://www.thethunderbolt.net/hidden-events-source/2025/6/19/cats-on-the-moon-corperate-retreat"><strong>Tickets and details here</strong></a>
-        </p>
+        <p>Thanks to Cathal Dowd, Fubar, Jo Capraldi, Joey Dawson, The Trapdoor Spiders, and especially Cats on the Moon for all the love and support during the 18 month run of live Corporate Retreat, Gunkus, and Leonardo Lemuel performance. Special thanks to Jenny Brock for the album art and posters. And of course thanks to the band members for 3+ years of developing Andrew into being a much better musician and getting him into the music business.</p>
 
         <h2>Where am I?</h2>
 


### PR DESCRIPTION
## Summary
- drop the cancelled Cats on the Moon show
- announce Corporate Retreat's hiatus and Andrew's plans
- delete the no-longer-used gig poster

## Testing
- `yamllint .`


------
https://chatgpt.com/codex/tasks/task_b_685504044cbc832a836c5bfd48360cce